### PR TITLE
Fix document list empty check

### DIFF
--- a/src/pages/DocumentsList/DocumetsList.jsx
+++ b/src/pages/DocumentsList/DocumetsList.jsx
@@ -51,7 +51,7 @@ function DocumentsList() {
     }
   }, [error]);
 
-  if (documents?.length === 0)
+  if (isValidDocumentsArray && documents.body.length === 0)
     return (
       <StateContainerWrapper>
         <ErrorHandler message='Lista dokumenata je prazna.'></ErrorHandler>


### PR DESCRIPTION
## Summary
- fix empty-list condition in DocumentsList page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6840088bfdf483208fc350387c98472a